### PR TITLE
Remove single quotes from destination paths that include spaces.

### DIFF
--- a/winrmcp/cp.go
+++ b/winrmcp/cp.go
@@ -116,7 +116,7 @@ func restoreContent(client *winrm.Client, fromPath, toPath string) error {
 	defer shell.Close()
 	script := fmt.Sprintf(`
 		$tmp_file_path = [System.IO.Path]::GetFullPath("%s")
-		$dest_file_path = [System.IO.Path]::GetFullPath("%s")
+		$dest_file_path = [System.IO.Path]::GetFullPath("%s".Trim("'"))
 		if (Test-Path $dest_file_path) {
 			rm $dest_file_path
 		}


### PR DESCRIPTION
When `toPath` contains one or more spaces, it is wrapped in single quotes.  If `toPath` also begins with a volume identifier (e.g. `C:`), the opening single quote offsets the colon (`:`) by one position in the string.  This results in a **NotSupportedException** exception being thrown during the call to `GetFullPath()`.

The solution is to always trim single quotes from `toPath` before the call to `GetFullPath()` is made.
